### PR TITLE
Fix potential Nullpointer Crash in pci.c ; Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ MY_CFLAGS += -DWITHOUT_NVME_PATCH
 #MY_CFLAGS += -g -DDEBUG
 ccflags-y += ${MY_CFLAGS}
 CC += ${MY_CFLAGS}
+KSRC := /lib/modules/$(shell uname -r)/build
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C $(KSRC) M=$(PWD) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C $(KSRC) M=$(PWD) clean
+	

--- a/pci.c
+++ b/pci.c
@@ -116,14 +116,15 @@ fail_interrupt:
 fail_interrupt_0:
     pci_free_irq(dev, 0, dev);
 fail:
-    if (bce && bce->dev)
+    if (bce && bce->dev) {
         device_destroy(bce_class, bce->devt);
-    kfree(bce);
+        if (!IS_ERR_OR_NULL(bce->reg_mem_mb))
+            pci_iounmap(dev, bce->reg_mem_mb);
+        if (!IS_ERR_OR_NULL(bce->reg_mem_dma))
+            pci_iounmap(dev, bce->reg_mem_dma);
+        kfree(bce);
+        }
 
-    if (!IS_ERR_OR_NULL(bce->reg_mem_mb))
-        pci_iounmap(dev, bce->reg_mem_mb);
-    if (!IS_ERR_OR_NULL(bce->reg_mem_dma))
-        pci_iounmap(dev, bce->reg_mem_dma);
 
     pci_free_irq_vectors(dev);
     pci_release_regions(dev);


### PR DESCRIPTION
If there are not enough interupts allocated, pci.c causes a nullpointer crash in cleanup. 
Update the Makefile to make it easyer to deal with different kernel versions. 