### PR TITLE
make it compile and run properly with a more recent kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ ccflags-y += ${MY_CFLAGS}
 CC += ${MY_CFLAGS}
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
+
+install:
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules_install
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean

--- a/mailbox.c
+++ b/mailbox.c
@@ -49,7 +49,8 @@ static int bce_mailbox_retrive_response(struct bce_mailbox *mb)
     u32 __iomem *regb;
     u32 lo, hi;
     int count, counter;
-    u32 res = ioread32((u8*) mb->reg_mb + REG_MBOX_REPLY_COUNTER);
+    static u32 res = 0;
+    res = ioread32((u8*) mb->reg_mb + REG_MBOX_REPLY_COUNTER);
     count = (res >> 20) & 0xf;
     counter = count;
     pr_debug("bce_mailbox_retrive_response count=%i\n", count);
@@ -67,7 +68,8 @@ static int bce_mailbox_retrive_response(struct bce_mailbox *mb)
 
 int bce_mailbox_handle_interrupt(struct bce_mailbox *mb)
 {
-    int status = bce_mailbox_retrive_response(mb);
+    static int status = 0;
+    status = bce_mailbox_retrive_response(mb);
     if (!status) {
         atomic_set(&mb->mb_status, 2);
         complete(&mb->mb_completion);

--- a/pci.c
+++ b/pci.c
@@ -17,8 +17,8 @@ static int bce_register_command_queue(struct bce_device *bce, struct bce_queue_m
 
 static int bce_probe(struct pci_dev *dev, const struct pci_device_id *id)
 {
-    struct bce_device *bce = NULL;
-    int status = 0;
+    static struct bce_device *bce = NULL;
+    static int status = 0;
     int nvec;
 
     pr_info("bce: capturing our device\n");
@@ -220,7 +220,8 @@ static int bce_register_command_queue(struct bce_device *bce, struct bce_queue_m
     int cmd_type;
     u64 result;
     // OS X uses an bidirectional direction, but that's not really needed
-    dma_addr_t a = dma_map_single(&bce->pci->dev, cfg, sizeof(struct bce_queue_memcfg), DMA_TO_DEVICE);
+    static dma_addr_t a = 0;
+    a = dma_map_single(&bce->pci->dev, cfg, sizeof(struct bce_queue_memcfg), DMA_TO_DEVICE);
     if (dma_mapping_error(&bce->pci->dev, a))
         return -ENOMEM;
     cmd_type = is_sq ? BCE_MB_REGISTER_COMMAND_SQ : BCE_MB_REGISTER_COMMAND_CQ;
@@ -262,8 +263,8 @@ static int bce_save_state_and_sleep(struct bce_device *bce)
     int attempt, status = 0;
     u64 resp;
     dma_addr_t dma_addr;
-    void *dma_ptr = NULL;
-    size_t size = max(PAGE_SIZE, 4096UL);
+    static void *dma_ptr = NULL;
+    static size_t size = max(PAGE_SIZE, 4096UL);
 
     for (attempt = 0; attempt < 5; ++attempt) {
         pr_debug("bce: suspend: attempt %i, buffer size %li\n", attempt, size);

--- a/queue.c
+++ b/queue.c
@@ -69,7 +69,7 @@ static void bce_handle_cq_completion(struct bce_device *dev, struct bce_qe_compl
 
 void bce_handle_cq_completions(struct bce_device *dev, struct bce_queue_cq *cq)
 {
-    size_t ce = 0;
+    static size_t ce = 0;
     struct bce_qe_completion *e;
     struct bce_queue_sq *sq;
     e = bce_cq_element(cq, cq->index);
@@ -319,7 +319,8 @@ struct bce_queue_cq *bce_create_cq(struct bce_device *dev, u32 el_count)
 {
     struct bce_queue_cq *cq;
     struct bce_queue_memcfg cfg;
-    int qid = ida_simple_get(&dev->queue_ida, BCE_QUEUE_USER_MIN, BCE_QUEUE_USER_MAX, GFP_KERNEL);
+    static int qid = 0;
+    qid = ida_simple_get(&dev->queue_ida, BCE_QUEUE_USER_MIN, BCE_QUEUE_USER_MAX, GFP_KERNEL);
     if (qid < 0)
         return NULL;
     cq = bce_alloc_cq(dev, qid, el_count);


### PR DESCRIPTION
make it compile and run properly with a more recent kernel, eg. 5.15.0-139-generic on Ubuntu 20.04.

One needs to also reinstall the kernel headers to match the current kernel so the module can be properly registered. However perhaps it's sufficient by just removing older unused kernel headers. Did this in a hurry.